### PR TITLE
Add download type and version prefix options to Zscaler recipes

### DIFF
--- a/Zscaler/Zscaler.download.recipe
+++ b/Zscaler/Zscaler.download.recipe
@@ -3,13 +3,19 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Downloads the latest Zscaler. Set INCLUDE_LIMITED to True to include limited availability releases.</string>
+        <string>Downloads the latest Zscaler. Set INCLUDE_LIMITED to True to include limited availability releases. Set DOWNLOAD_TYPE to 'pkg' for a .pkg installer (default is 'app'). Set VERSION_PREFIX to e.g. '4.5' to pin to an LTS branch.</string>
         <key>Identifier</key>
         <string>com.github.rickheil-recipes.download.Zscaler</string>
         <key>Input</key>
         <dict>
             <key>NAME</key>
             <string>Zscaler</string>
+            <key>INCLUDE_LIMITED</key>
+            <string></string>
+            <key>DOWNLOAD_TYPE</key>
+            <string>app</string>
+            <key>VERSION_PREFIX</key>
+            <string></string>
         </dict>
         <key>MinimumVersion</key>
         <string>1.4</string>
@@ -22,6 +28,10 @@
                 <dict>
                     <key>include_limited</key>
                     <string>%INCLUDE_LIMITED%</string>
+                    <key>download_type</key>
+                    <string>%DOWNLOAD_TYPE%</string>
+                    <key>version_prefix</key>
+                    <string>%VERSION_PREFIX%</string>
                 </dict>
             </dict>
             <dict>

--- a/Zscaler/Zscaler.munki.recipe
+++ b/Zscaler/Zscaler.munki.recipe
@@ -10,6 +10,10 @@
         <dict>
             <key>INCLUDE_LIMITED</key>
             <string></string>
+            <key>DOWNLOAD_TYPE</key>
+            <string>app</string>
+            <key>VERSION_PREFIX</key>
+            <string></string>
             <key>MUNKI_REPO_SUBDIR</key>
             <string>apps</string>
             <key>NAME</key>

--- a/Zscaler/ZscalerURLProvider.py
+++ b/Zscaler/ZscalerURLProvider.py
@@ -140,9 +140,9 @@ class ZscalerURLProvider(URLGetter):
         notes_data_url = self.env.get("notes_data_url", NOTES_DATA_URL)
         if notes_data_url != NOTES_DATA_URL:
             self.output(f"NOTES_DATA_URL overridden to {notes_data_url}", 3)
-        download_type = self.env.get("download_type", DOWNLOAD_TYPE).lower()
+        download_type = self.env.get("download_type", DOWNLOAD_TYPE).lower() or DOWNLOAD_TYPE
         if download_type not in ("app", "pkg"):
-            raise ValueError(f"Invalid download_type '{download_type}'. Must be 'app' or 'pkg'.")
+            raise ProcessorError(f"Invalid download_type '{download_type}'. Must be 'app' or 'pkg'.")
         if download_type != DOWNLOAD_TYPE:
             self.output(f"DOWNLOAD_TYPE overridden to {download_type}", 3)
         version_prefix = self.env.get("version_prefix", VERSION_PREFIX)

--- a/Zscaler/ZscalerURLProvider.py
+++ b/Zscaler/ZscalerURLProvider.py
@@ -33,6 +33,8 @@ NOTES_DATA_URL = "https://help.zscaler.com/zapi/fetch-data?url_alias=/client-con
 
 INCLUDE_LIMITED = False
 CLOUDFRONT_DISTRO = "https://d32a6ru7mhaq0c.cloudfront.net"
+DOWNLOAD_TYPE = "app"
+VERSION_PREFIX = ""
 
 class ZscalerURLProvider(URLGetter):
     """Provides URL to the latest Zscaler client release."""
@@ -55,7 +57,20 @@ class ZscalerURLProvider(URLGetter):
             "required": False,
             "description": (
                 f"URL for Zscaler Cloudfront distribution point. Defaults to '{CLOUDFRONT_DISTRO}'."
-
+            ),
+        },
+        "download_type": {
+            "required": False,
+            "description": (
+                "Type of download: 'app' for .app.zip or 'pkg' for .pkg. "
+                f"Defaults to '{DOWNLOAD_TYPE}'."
+            ),
+        },
+        "version_prefix": {
+            "required": False,
+            "description": (
+                "Only consider versions starting with this prefix, e.g. '4.5' "
+                "to select the LTS branch. Defaults to '' (no filtering)."
             ),
         },
     }
@@ -71,9 +86,9 @@ class ZscalerURLProvider(URLGetter):
         },
     }
 
-    def get_zscaler_version(self, notes_data_url, include_limited):
+    def get_zscaler_version(self, notes_data_url, include_limited, version_prefix):
         """Returns the latest version number by scraping release notes."""
-        self.output(f"Using default notes_data_url of {notes_data_url}", 3)
+        self.output(f"Using notes_data_url of {notes_data_url}", 3)
         json_response = self.download(notes_data_url)
         zscaler_info = json.loads(json_response)
         self.output(zscaler_info, 4)
@@ -93,6 +108,15 @@ class ZscalerURLProvider(URLGetter):
                     self.output(f"Found GA release {extracted} - adding to list.", 3)
                     versions.append(extracted)
 
+        # filter by version prefix if specified
+        if version_prefix:
+            filtered = [v for v in versions if v.startswith(version_prefix)]
+            self.output(
+                f"Filtering versions by prefix '{version_prefix}': "
+                f"{len(filtered)} of {len(versions)} matched.", 2
+            )
+            versions = filtered
+
         # compare all extracted versions to find highest
         newest_version = None
         for version in versions:
@@ -110,13 +134,26 @@ class ZscalerURLProvider(URLGetter):
         notes_data_url = self.env.get("notes_data_url", NOTES_DATA_URL)
         if notes_data_url != NOTES_DATA_URL:
             self.output(f"NOTES_DATA_URL overridden to {notes_data_url}", 3)
+        download_type = self.env.get("download_type", DOWNLOAD_TYPE).lower()
+        if download_type not in ("app", "pkg"):
+            raise ValueError(f"Invalid download_type '{download_type}'. Must be 'app' or 'pkg'.")
+        if download_type != DOWNLOAD_TYPE:
+            self.output(f"DOWNLOAD_TYPE overridden to {download_type}", 3)
+        version_prefix = self.env.get("version_prefix", VERSION_PREFIX)
+        if version_prefix:
+            self.output(f"VERSION_PREFIX set to '{version_prefix}'", 3)
+        cloudfront_distro = self.env.get("cloudfront_distro_url", CLOUDFRONT_DISTRO)
 
         # get latest version number
-        version = self.get_zscaler_version(notes_data_url, include_limited)
+        version = self.get_zscaler_version(notes_data_url, include_limited, version_prefix)
 
-        # assemble output
-        self.env["url"] = f"{CLOUDFRONT_DISTRO}/Zscaler-osx-{version}-installer.app.zip"
-        self.env["filename"] = f"Zscaler-osx-{version}-installer.app.zip"
+        # assemble output based on download type
+        if download_type == "pkg":
+            self.env["url"] = f"{cloudfront_distro}/Zscaler-osx-{version}-installer.pkg"
+            self.env["filename"] = f"Zscaler-osx-{version}-installer.pkg"
+        else:
+            self.env["url"] = f"{cloudfront_distro}/Zscaler-osx-{version}-installer.app.zip"
+            self.env["filename"] = f"Zscaler-osx-{version}-installer.app.zip"
         self.env["version"] = version
 
 

--- a/Zscaler/ZscalerURLProvider.py
+++ b/Zscaler/ZscalerURLProvider.py
@@ -21,6 +21,7 @@ import re
 from distutils.version import LooseVersion
 import sys
 sys.path.insert(0, "/Library/AutoPkg")
+from autopkglib import ProcessorError
 from autopkglib.URLGetter import URLGetter
 
 __all__ = ["ZscalerURLProvider"]
@@ -123,6 +124,11 @@ class ZscalerURLProvider(URLGetter):
             self.output(f"Processing found version {version}")
             if newest_version is None or LooseVersion(version) > LooseVersion(newest_version):
                 newest_version = version
+        if newest_version is None:
+            raise ProcessorError(
+                f"No Zscaler versions found"
+                f"{' matching prefix ' + repr(version_prefix) if version_prefix else ''}."
+            )
         self.output(f"Found newest version of Zscaler Client Connector as {newest_version}.")
         return newest_version
 


### PR DESCRIPTION
## Summary
  - Adds `DOWNLOAD_TYPE` input variable to select between `.app.zip` (default) and `.pkg` downloads
  - Adds `VERSION_PREFIX` input variable to filter versions by prefix (e.g. `4.5`) for LTS branch pinning
  - Raises `ProcessorError` with a clear message when no versions match the given prefix
  - Handles empty string inputs gracefully (common in recipe overrides)
  - Fixes `cloudfront_distro_url` input variable which was defined but never used

  ## Usage
  ```xml
  <key>Input</key>
  <dict>
      <key>DOWNLOAD_TYPE</key>
      <string>pkg</string>
      <key>VERSION_PREFIX</key>
      <string>4.5</string>
  </dict>

  Test plan

  - Default (no inputs) — returns latest version as .app.zip
  - download_type=pkg — returns latest version as .pkg
  - version_prefix=4.5 — returns latest 4.5.x version
  - Both pkg + version_prefix=4.5 — returns latest 4.5.x as .pkg
  - Non-existent prefix — raises ProcessorError
  - Empty download_type — falls back to app default