### PR TITLE
ZscalerURLProvider: iterate all items in available/limited arrays

### DIFF
--- a/Zscaler/README.md
+++ b/Zscaler/README.md
@@ -18,7 +18,7 @@ This recipe is forked from an initial idea by @williamtheaker on Github to use t
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DOWNLOAD_TYPE` | `app` | `app` for .app.zip, `pkg` for .pkg installer |
-| `VERSION_PREFIX` | *(empty)* | Filter versions by prefix, e.g. `4.5` to pin to an LTS branch |
+| `VERSION_PREFIX` | *(empty)* | Filter versions by prefix, e.g. `4.5.2` to pin to an LTS branch |
 | `INCLUDE_LIMITED` | *(empty)* | Set to `True` to include limited availability (beta) releases |
 
 ### Munki options (Zscaler.munki.recipe only)
@@ -45,7 +45,7 @@ autopkg run com.github.rickheil-recipes.munki.Zscaler
 autopkg run com.github.rickheil-recipes.munki.ZscalerPkg
 ```
 
-### Pin to LTS branch (e.g. 4.5)
+### Pin to LTS branch (e.g. 4.5.2)
 
 In your recipe override, set:
 
@@ -53,7 +53,7 @@ In your recipe override, set:
 <key>Input</key>
 <dict>
     <key>VERSION_PREFIX</key>
-    <string>4.5</string>
+    <string>4.5.2</string>
 </dict>
 ```
 

--- a/Zscaler/Zscaler.download.recipe
+++ b/Zscaler/Zscaler.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Downloads the latest Zscaler. Set INCLUDE_LIMITED to True to include limited availability releases. Set DOWNLOAD_TYPE to 'pkg' for a .pkg installer (default is 'app'). Set VERSION_PREFIX to e.g. '4.5' to pin to an LTS branch.</string>
+        <string>Downloads the latest Zscaler. Set INCLUDE_LIMITED to True to include limited availability releases. Set DOWNLOAD_TYPE to 'pkg' for a .pkg installer (default is 'app'). Set VERSION_PREFIX to e.g. '4.5.2' to pin to an LTS branch.</string>
         <key>Identifier</key>
         <string>com.github.rickheil-recipes.download.Zscaler</string>
         <key>Input</key>

--- a/Zscaler/ZscalerPkg.munki.recipe
+++ b/Zscaler/ZscalerPkg.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Downloads the latest Zscaler .pkg installer and imports it into Munki. Set VERSION_PREFIX to e.g. '4.5' to pin to an LTS branch.</string>
+        <string>Downloads the latest Zscaler .pkg installer and imports it into Munki. Set VERSION_PREFIX to e.g. '4.5.2' to pin to an LTS branch.</string>
         <key>Identifier</key>
         <string>com.github.rickheil-recipes.munki.ZscalerPkg</string>
         <key>Input</key>

--- a/Zscaler/ZscalerURLProvider.py
+++ b/Zscaler/ZscalerURLProvider.py
@@ -70,7 +70,7 @@ class ZscalerURLProvider(URLGetter):
         "version_prefix": {
             "required": False,
             "description": (
-                "Only consider versions starting with this prefix, e.g. '4.5' "
+                "Only consider versions starting with this prefix, e.g. '4.5.2' "
                 "to select the LTS branch. Defaults to '' (no filtering)."
             ),
         },

--- a/Zscaler/ZscalerURLProvider.py
+++ b/Zscaler/ZscalerURLProvider.py
@@ -97,17 +97,19 @@ class ZscalerURLProvider(URLGetter):
         for entry in zscaler_info["data"]["body"]["release_notes"]["entries"]:
             entry_data = zscaler_info["data"]["body"]["release_notes"]["entries"][entry]
             if "limited" in entry_data["release"]:
-                extracted = re.search(r"Client\ Connector\ ([\d\.]*)\ for macOS",
-                                      entry_data["release"]["limited"][0]["title"]).group(1)
-                if len(extracted) > 0 and include_limited:
-                    self.output(f"Found limited release {extracted} - adding to list.", 3)
-                    versions.append(extracted)
+                for item in entry_data["release"]["limited"]:
+                    match = re.search(r"Client\ Connector\ ([\d\.]*)\ for macOS",
+                                      item["title"])
+                    if match and match.group(1) and include_limited:
+                        self.output(f"Found limited release {match.group(1)} - adding to list.", 3)
+                        versions.append(match.group(1))
             if "available" in entry_data["release"]:
-                extracted = re.search(r"Client\ Connector\ ([\d\.]*)\ for macOS",
-                                      entry_data["release"]["available"][0]["title"]).group(1)
-                if len(extracted) > 0:
-                    self.output(f"Found GA release {extracted} - adding to list.", 3)
-                    versions.append(extracted)
+                for item in entry_data["release"]["available"]:
+                    match = re.search(r"Client\ Connector\ ([\d\.]*)\ for macOS",
+                                      item["title"])
+                    if match and match.group(1):
+                        self.output(f"Found GA release {match.group(1)} - adding to list.", 3)
+                        versions.append(match.group(1))
 
         # filter by version prefix if specified
         if version_prefix:


### PR DESCRIPTION
## Summary
- Some release note entries contain multiple macOS releases in the same `available` or `limited` array (e.g. both a 4.7.x and a 4.5.x GA release)
- Previously only the first item (`[0]`) was read, causing versions like 4.5.2.175 to be silently skipped
- Now iterates over all items in each array so all published versions are discovered

## Test plan
- [x] Run `autopkg run -vvv` with a Zscaler recipe and verify all GA/limited versions appear in the output
- [x] Verify `version_prefix` filtering still works correctly with the full version list